### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/graysonarts/leptos-calendar/compare/v0.1.1...v0.1.2) - 2025-02-06
+
+### Other
+
+- leptos version from 0.6 to 0.7
+
 ## [0.1.1](https://github.com/graysonarts/leptos-calendar/compare/v0.1.0...v0.1.1) - 2024-11-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_calendar"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_calendar"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "A calendar component for leptos apps"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `leptos_calendar`: 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/graysonarts/leptos-calendar/compare/v0.1.1...v0.1.2) - 2025-02-06

### Other

- leptos version from 0.6 to 0.7
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).